### PR TITLE
Now with 100% more Freifunk

### DIFF
--- a/satzung.tex
+++ b/satzung.tex
@@ -62,6 +62,8 @@
 
       \item Kunst und Kultur in Hinblick auf den schöpferischen Umgang mit
         Technologie zu fördern.
+        
+      \item Die Förderung des Freifunks, insbesondere des regionalen Freifunks.
     \end{itemize}
 
   \item Der Vereinszweck soll insbesondere verwirklicht werden durch:
@@ -75,6 +77,9 @@
       \item die Zusammenarbeit und der Austausch mit nationalen und
         internationalen Gruppierungen, deren Ziele mit denen des Vereins
         vereinbar sind.
+        
+      \item den Betrieb, die Pflege und die Weiterentwicklung der Freifunk Infrastruktur sowie
+        die Organisation der regionalen Freifunkgemeinschaft.
     \end{itemize}
 \end{enumerate}
 


### PR DESCRIPTION
```
      \item den Betrieb, die Pflege und die Weiterentwicklung der Freifunk Infrastruktur sowie
        die Organisation der regionalen Freifunkgemeinschaft.
```
Dieser Absatz ist IMHO nicht notwendig, weil durch abgedeckt wenn Freifunk im Zweck steht.
Würde den weglassen.
```

      \item die Bereitstellung und Pflege einer Räumlichkeit sowie der zur
        Verwirklichung der Vereinszwecke nötigen Infrastruktur.

      \item die Organisation und Durchführung von lokalen Zusammenkünften und
        Informationsveranstaltungen sowie Öffentlichkeitsarbeit.

```
`sowie der zur
        Verwirklichung der Vereinszwecke nötigen Infrastruktur.`
Ist das ganz Freifunknetz, wenn Freifunk im Zweck.

`      \item die Organisation und Durchführung von lokalen Zusammenkünften und
        Informationsveranstaltungen sowie Öffentlichkeitsarbeit.`

Ist die Frefunkgemeinschaft, wenn Freifunk im Zweck.